### PR TITLE
Add type hints, mypy check, and refactor the complete project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,16 +34,21 @@ repos:
     hooks:
       - id: isort
 
-  # TODO:
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v0.961
-  #   hooks:
-  #     - id: mypy
-  #       files: src
-  #       args: [--show-error-codes]
-  #       additional_dependencies:
-  #         - numpy==1.22.0
-  #         - packaging
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.961
+    hooks:
+      - id: mypy
+        files: ocred
+        args: [--show-error-codes]
+        additional_dependencies:
+          - numpy==1.22.0
+          - easyocr
+          - scipy
+          - gtts
+          - nltk
+          - pytesseract
+          - opencv-python
+          - packaging
 
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,11 +42,6 @@ repos:
         args: [--show-error-codes]
         additional_dependencies:
           - numpy==1.22.0
-          - easyocr
-          - scipy
-          - gtts
-          - nltk
-          - pytesseract
           - opencv-python
           - packaging
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,6 @@ repos:
         args: [--show-error-codes]
         additional_dependencies:
           - numpy==1.22.0
-          - opencv-python
           - packaging
 
   - repo: https://github.com/PyCQA/flake8

--- a/README.md
+++ b/README.md
@@ -85,28 +85,34 @@ import cv2
 from scipy import ndimage
 from ocred import Preprocessor
 
-preprocess = Preprocessor("path/to/an/image")
+preprocessed = Preprocessor("path/to/image")
 
 # scan the image and copy the scanned image
-scanned = preprocess.scan()
+scanned = preprocessed.scan(inplace=True)
 orig = scanned.copy()
 
 # remove noise
-noise_free = preprocess.remove_noise(scanned)
+noise_free = preprocessed.remove_noise(
+    inplace=True, overriden_image=scanned
+)
 
 # thicken the ink to draw Hough lines better
-thickened = preprocess.thicken_font(noise_free)
+thickened = preprocessed.thicken_font(
+    inplace=True, overriden_image=noise_free
+)
 
 # calculate the median angle of all the Hough lines
-_, median_angle = preprocess.rotate(thickened)
+_, median_angle = preprocessed.rotate(
+    inplace=True, overriden_image=thickened
+)
 
 # rotate the original scanned image
-preprocessed = ndimage.rotate(orig, median_angle)
+rotated = ndimage.rotate(orig, median_angle)
 
 # remove noise again
-preprocessed = preprocess.remove_noise(preprocessed)
+final_img = preprocessed.remove_noise(inplace=True, overriden_image=rotated)
 
-cv2.imwrite("preprocessed.png", preprocessed)
+cv2.imwrite("preprocessed.png", final_img)
 ```
 
 ## Testing

--- a/ocred/ocr.py
+++ b/ocred/ocr.py
@@ -20,13 +20,15 @@ class OCR:
 
     Args:
 
-        preprocess (bool):
+        preprocess:
             Set True if the image is a real life photo of some large meaningful (page of a
             book). Usually set to False when OCRing using `ocr_meaningful_text` to
             preprocess the image.
             Set False if the image is a scanned photo (an e-book). It will not be
             pre-processed before OCRing.
-        path (str):
+            All the preprocessing is performed inplace to maintain efficiency. Use the
+            `Preprocessor` class manually to have more control!
+        path:
             Path of the image to be used.
 
     Examples:
@@ -83,11 +85,11 @@ class OCR:
         around the words. For example - books, PDFs etc.
 
         Args:
-            save_output (bool):
+            save_output:
                 Saves the text to `output.txt` file.
 
         Returns:
-            text (str):
+            text:
                 The extracted text.
         """
         # reading the image
@@ -132,18 +134,18 @@ class OCR:
         for example - bills, sign-boards etc.
 
         Args:
-            languages (list (default = ["en", "hi"] where "en" = English and "hi" = Hindi)):
+            languages:
                 A list of languages that the signboard possible has.
                 Note: Provide only the languages that are present in the image, adding
                 additional languages misguides the model.
-            decoder (str):
+            decoder:
                 If the document has a larger number of meaningful sentences then use
                 "beamsearch". For most of the cases "greedy" works very well.
-            save_output (bool):
+            save_output:
                 Saves the text to `output.txt` file.
 
         Returns:
-            text (str):
+            text:
                 The extracted text.
         """
         self.text = ""
@@ -185,7 +187,7 @@ class OCR:
         information.
 
         Returns:
-            extracted_info (dict):
+            extracted_info:
                 The extracted information.
         """
         nltk.download("punkt")
@@ -277,7 +279,7 @@ class OCR:
         Converts the extracted text to speech and save it as an MP3 file.
 
         Args:
-            lang (str (default = "en" where "en" is English)):
+            lang:
                 Language of the processed text.
         """
         speech = gTTS(self.text, lang="en", tld="com")

--- a/ocred/ocr.py
+++ b/ocred/ocr.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any, Dict, List, Optional, Union
 
 import cv2
 import easyocr
@@ -41,36 +42,42 @@ class OCR:
         >>> ocr.text_to_speech()
     """
 
-    def __init__(self, preprocess, path, tesseract_location=None):
+    def __init__(self, preprocess: bool, path: str) -> None:
         self.path = path
         self.preprocess = preprocess
 
         if self.preprocess:
-            preprocess = Preprocessor(self.path)
+            preprocessed = Preprocessor(self.path)
 
             # scan the image and copy the scanned image
-            scanned = preprocess.scan()
+            scanned = preprocessed.scan(inplace=True)
             orig = scanned.copy()
 
             # remove noise
-            noise_free = preprocess.remove_noise(scanned)
+            noise_free = preprocessed.remove_noise(
+                inplace=True, overriden_image=scanned
+            )
 
             # thicken the ink to draw Hough lines better
-            thickened = preprocess.thicken_font(noise_free)
+            thickened = preprocessed.thicken_font(
+                inplace=True, overriden_image=noise_free
+            )
 
             # calculate the median angle of all the Hough lines
-            _, median_angle = preprocess.rotate(thickened)
+            _, median_angle = preprocessed.rotate(
+                inplace=True, overriden_image=thickened
+            )
 
             # rotate the original scanned image
-            preprocessed = ndimage.rotate(orig, median_angle)
+            rotated = ndimage.rotate(orig, median_angle)
 
             # remove noise again
-            preprocessed = preprocess.remove_noise(preprocessed)
+            final_img = preprocessed.remove_noise(inplace=True, overriden_image=rotated)
 
-            cv2.imwrite("preprocessed.png", preprocessed)
+            cv2.imwrite("preprocessed.png", final_img)
             self.path = "preprocessed.png"
 
-    def ocr_meaningful_text(self, save_output=False):
+    def ocr_meaningful_text(self, *, save_output: Optional[bool] = False) -> str:
         """
         Performs OCR on long meaningful text documents and saves the image with boxes
         around the words. For example - books, PDFs etc.
@@ -112,8 +119,12 @@ class OCR:
         return self.text
 
     def ocr_sparse_text(
-        self, languages=["en", "hi"], decoder="greedy", save_output=False
-    ):
+        self,
+        *,
+        languages: Optional[List[str]] = ["en", "hi"],
+        decoder: Optional[str] = "greedy",
+        save_output: Optional[bool] = False,
+    ) -> str:
         """
         Performs OCR on sparse text and saves the image with boxes around the words.
         This method can be used to OCR documents in which the characters don't form any
@@ -168,7 +179,7 @@ class OCR:
 
         return self.text
 
-    def process_extracted_text_from_invoice(self):
+    def process_extracted_text_from_invoice(self) -> Dict[str, Any]:
         """
         This method processes the extracted text from invoices, and returns some useful
         information.
@@ -209,7 +220,7 @@ class OCR:
         ]
 
         # find order number
-        order_number = ""
+        order_number: Union[str, int] = ""
         for i in range(len(post_processed_word_list)):
             if post_processed_word_list[i].lower() == "order":
                 try:
@@ -219,7 +230,7 @@ class OCR:
                 break
 
         # find total price
-        price = ""
+        price: Union[List[Any], str] = ""
 
         # try finding a number with Rs, INR, ₹ or रे in front of it or Rs, INR at the end
         # of it
@@ -255,13 +266,13 @@ class OCR:
 
         return self.extracted_info
 
-    def save_output(self):
+    def save_output(self) -> None:
         """Saves the extracted text in the `output.txt` file."""
         f = open("output.txt", "w", encoding="utf-8")
         f.write(self.text)
         f.close()
 
-    def text_to_speech(self, lang="en"):
+    def text_to_speech(self, *, lang: Optional[str] = "en") -> None:
         """
         Converts the extracted text to speech and save it as an MP3 file.
 

--- a/ocred/preprocessing.py
+++ b/ocred/preprocessing.py
@@ -13,29 +13,35 @@ class Preprocessor:
     Preprocesses an image and makes it ready for OCR.
 
     Args:
-        path (str):
-            Path of the image.
+        image:
+            Path of the image or a numpy array.
 
     Examples:
         >>> import cv2
         >>> from scipy import ndimage
         >>> from ocred import Preprocessor
         >>> # scan the image and copy the scanned image
-        >>> preprocess = Preprocessor("images/CosmosTwo.jpg")
+        >>> preprocessed = Preprocessor("images/CosmosTwo.jpg")
         >>> # scan the image and copy the scanned image
-        >>> scanned = preprocess.scan()
+        >>> scanned = preprocessed.scan(inplace=True)
         >>> orig = scanned.copy()
         >>> # remove noise
-        >>> noise_free = preprocess.remove_noise(scanned)
+        ... noise_free = preprocessed.remove_noise(
+        ...     inplace=True, overriden_image=scanned
+        ... )
         >>> # thicken the ink to draw Hough lines better
-        >>> thickened = preprocess.thicken_font(noise_free)
+        >>> thickened = preprocessed.thicken_font(
+        ...     inplace=True, overriden_image=noise_free
+        ... )
         >>> # calculate the median angle of all the Hough lines
-        >>> _, median_angle = preprocess.rotate(thickened)
+        >>> _, median_angle = preprocessed.rotate(
+        ...     inplace=True, overriden_image=thickened
+        ... )
         >>> # rotate the original scanned image
-        >>> preprocessed = ndimage.rotate(orig, median_angle)
+        >>> rotated = ndimage.rotate(orig, median_angle)
         >>> # remove noise again
-        >>> preprocessed = preprocess.remove_noise(preprocessed)
-        >>> cv2.imwrite("preprocessed.png", preprocessed)
+        >>> final_img = preprocessed.remove_noise(inplace=True, overriden_image=rotated)
+        >>> cv2.imwrite("preprocessed.png", final_img)
         True
     """
 
@@ -62,13 +68,17 @@ class Preprocessor:
         Removes noise from an image.
 
         Args:
-            save (bool):
+            save:
                 Saves the resultant image.
-            iterations (int):
+            inplace:
+                Edits the image inplace.
+            iterations:
                 Number of times the image is processed.
+            overriden_image:
+                Overrides the image passes through the constructor.
 
         Returns:
-            noise_free_image (array):
+            noise_free_image:
                 The noise free image.
         """
         if not inplace:
@@ -102,13 +112,17 @@ class Preprocessor:
         Thickens the ink of an image.
 
         Args:
-            save (bool):
+            save:
                 Saves the resultant image.
-            iterations (int):
+            inplace:
+                Edits the image inplace.
+            iterations:
                 Number of times the image is processed.
+            overriden_image:
+                Overrides the image passes through the constructor.
 
         Returns:
-            thickened_image (array):
+            thickened_image:
                 The thickened image.
         """
         if not inplace:
@@ -139,13 +153,15 @@ class Preprocessor:
         Transforms an image/document view into B&W view (proper scanned colour scheme).
 
         Args:
-            image (array (default = image located at `path`)):
-                Pass an image to be scanned.
-            save (bool):
-                Saves the image.
+            save:
+                Saves the resultant image.
+            inplace:
+                Edits the image inplace.
+            overriden_image:
+                Overrides the image passes through the constructor.
 
         Returns:
-            scanned_image (array):
+            scanned_image:
                 The scanned image.
         """
         if not inplace:
@@ -175,14 +191,18 @@ class Preprocessor:
         Rotates an image for a face-on view (view from the top).
 
         Args:
-            image (array (default = image located at `path`)):
-                Pass an image to be rotated.
-            save (bool):
-                Saves the rotated image.
+            save:
+                Saves the resultant image.
+            inplace:
+                Edits the image inplace.
+            overriden_image:
+                Overrides the image passes through the constructor.
 
         Returns:
-            rotated_image (array):
+            rotated_image:
                 The rotated image.
+            median_angle:
+                The angly by which it is rotated.
         """
         if not inplace:
             img = self.img.copy() if overriden_image is None else overriden_image.copy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering",
+    "Typing :: Typed",
 ]
 dependencies = [
     "easyocr>=1.4.1",
@@ -90,12 +91,6 @@ addopts = [
 testpaths = [
     "tests",
 ]
-markers = [
-    "slow",
-    "numba",
-    "awkward",
-    "dis",
-]
 log_cli_level = "DEBUG"
 filterwarnings = [
     "error",
@@ -105,3 +100,19 @@ filterwarnings = [
 
 [tool.isort]
 profile = "black"
+
+[tool.mypy]
+files = [
+    "./ocred/",
+]
+python_version = "3.8"
+strict = true
+warn_return_any = false
+show_error_codes = true
+warn_unreachable = true
+enable_error_code = [
+    "ignore-without-code",
+    "truthy-bool",
+    "redundant-expr",
+]
+ignore_missing_imports = true

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -22,8 +22,9 @@ def test_scan():
     os.remove("scanned.png")
 
     img = cv2.imread(path)
+    pre = Preprocessor(img)
 
-    image = pre.scan(overriden_image=img)
+    image = pre.scan()
     assert isinstance(image, np.ndarray)
 
     orig = img.copy()

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -10,7 +10,7 @@ path = "images/CosmosOne.jpg"
 
 def test_scan():
     pre = Preprocessor(path)
-    assert pre.path == path
+    assert isinstance(pre.img, np.ndarray)
 
     img = pre.scan()
     assert isinstance(img, np.ndarray)
@@ -23,13 +23,13 @@ def test_scan():
 
     img = cv2.imread(path)
 
-    img = pre.scan(image=img)
+    img = pre.scan(overriden_image=img)
     assert isinstance(img, np.ndarray)
 
 
 def test_rotate():
     pre = Preprocessor(path)
-    assert pre.path == path
+    assert isinstance(pre.img, np.ndarray)
 
     img, median_angle = pre.rotate()
     assert isinstance(median_angle, float)
@@ -42,8 +42,8 @@ def test_rotate():
 
     os.remove("rotated.png")
 
-    img, median_angle = pre.rotate(image=img)
-    img1, median_angle = pre.rotate(image=img)
+    img, median_angle = pre.rotate(overriden_image=img)
+    img1, median_angle = pre.rotate(overriden_image=img)
     assert isinstance(median_angle, float)
     assert isinstance(img, np.ndarray)
     assert isinstance(img1, np.ndarray)
@@ -52,7 +52,7 @@ def test_rotate():
 
 def test_remove_noise():
     pre = Preprocessor(path)
-    assert pre.path == path
+    assert isinstance(pre.img, np.ndarray)
 
     img = pre.remove_noise()
     assert isinstance(img, np.ndarray)
@@ -63,13 +63,13 @@ def test_remove_noise():
 
     os.remove("noise_free.png")
 
-    img = pre.remove_noise(image=img)
+    img = pre.remove_noise(overriden_image=img)
     assert isinstance(img, np.ndarray)
 
 
 def test_thicken_font():
     pre = Preprocessor(path)
-    assert pre.path == path
+    assert isinstance(pre.img, np.ndarray)
 
     img = pre.thicken_font()
     assert isinstance(img, np.ndarray)
@@ -80,5 +80,5 @@ def test_thicken_font():
 
     os.remove("thick_font.png")
 
-    img = pre.thicken_font(image=img)
+    img = pre.thicken_font(overriden_image=img)
     assert isinstance(img, np.ndarray)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -23,8 +23,12 @@ def test_scan():
 
     img = cv2.imread(path)
 
-    img = pre.scan(overriden_image=img)
-    assert isinstance(img, np.ndarray)
+    image = pre.scan(overriden_image=img)
+    assert isinstance(image, np.ndarray)
+
+    orig = img.copy()
+    _ = pre.scan(inplace=True, overriden_image=img)
+    assert not np.testing.assert_array_equal(img, orig)
 
 
 def test_rotate():
@@ -49,6 +53,10 @@ def test_rotate():
     assert isinstance(img1, np.ndarray)
     np.testing.assert_array_equal(img, img1)
 
+    orig = img.copy()
+    _ = pre.rotate(inplace=True, overriden_image=img)
+    assert not np.testing.assert_array_equal(img, orig)
+
 
 def test_remove_noise():
     pre = Preprocessor(path)
@@ -66,6 +74,10 @@ def test_remove_noise():
     img = pre.remove_noise(overriden_image=img)
     assert isinstance(img, np.ndarray)
 
+    orig = img.copy()
+    _ = pre.remove_noise(inplace=True, overriden_image=img)
+    assert not np.testing.assert_array_equal(img, orig)
+
 
 def test_thicken_font():
     pre = Preprocessor(path)
@@ -82,3 +94,7 @@ def test_thicken_font():
 
     img = pre.thicken_font(overriden_image=img)
     assert isinstance(img, np.ndarray)
+
+    orig = img.copy()
+    _ = pre.thicken_font(inplace=True, overriden_image=img)
+    assert not np.testing.assert_array_equal(img, orig)


### PR DESCRIPTION
Closes #34 Closes #17
- Introduce memory efficient preprocessing (`inplace`)
- Refactor the `Preprocessor` class
- Update docs
- Add type hints
- Add `mypy` checks
- Update and add tests
- Make `Preprocessor` arguments not positional
- Add an `overriden_image` option and remove `image` arg